### PR TITLE
Fixing admin interface for models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,5 @@ ENV/
 
 # Database files
 *.db
+
+migrations/

--- a/social/author/admin.py
+++ b/social/author/admin.py
@@ -3,7 +3,7 @@ from author.models import *
 
 # Register admin models for admin interface
 class AuthorAdmin(admin.ModelAdmin):
-    fields = ('user', 'friend')
+    fields = ('id', 'friend')
 
 # Register your models here.
 admin.site.register(Author, AuthorAdmin)

--- a/social/author/models.py
+++ b/social/author/models.py
@@ -4,7 +4,7 @@ from django.conf import settings
 # Create your models here.
 
 class Author(models.Model):
-    user = models.OneToOneField(User, primary_key=True, max_length=32, on_delete=models.CASCADE) # This references the built-in django User object
+    id = models.OneToOneField(User, primary_key=True, max_length=32, on_delete=models.CASCADE) # This references the built-in django User object
     friend = models.ManyToManyField("self", related_name="friend", blank=True)
     
     def __str__(self):

--- a/social/author/views.py
+++ b/social/author/views.py
@@ -13,14 +13,14 @@ import sys
 def index(request):
     # This page displays the author's stream/post feed.
     # https://docs.djangoproject.com/en/1.10/topics/db/queries/
-    authorContext = Author.objects.get(user=request.user)
+    authorContext = Author.objects.get(id=request.user)
     feed = []
     # Get all post objects that are public and private
     # TODO: Add to the query to expand the feed.
     try:
         posts = Post.objects.filter(
             Q(privacyLevel=0) | 
-            (Q(privacyLevel=4) & Q(author=authorContext.user.id))
+            (Q(privacyLevel=4) & Q(author=authorContext.id.id))
             ).order_by('-publishDate')
     except:
         return HttpResponse(sys.exc_info[0])
@@ -47,7 +47,7 @@ def author_post(request):
         # Get the logged in user and the associated author object.
         #userContext = User.objects.get(username=request.user.username)
         post_body = request.POST['post_content']
-        authorContext = Author.objects.get(user=request.user)
+        authorContext = Author.objects.get(id=request.user)
 
         # Create and save a new post.
         newPost = Post(author=authorContext, content=request.POST['post_content'])

--- a/social/comment/admin.py
+++ b/social/comment/admin.py
@@ -3,7 +3,7 @@ from comment.models import *
 
 # Register your models here.
 class CommentAdmin(admin.ModelAdmin):
-    fields = ('id', 'author', 'content', 'publishDate')
+    fields = ('author', 'content', 'publishDate')
 
 # Register your models here.
 admin.site.register(Comment, CommentAdmin)

--- a/social/post/admin.py
+++ b/social/post/admin.py
@@ -3,7 +3,7 @@ from post.models import *
 
 # Register admin models for admin interface
 class PostAdmin(admin.ModelAdmin):
-    fields = ('id', 'author', 'content', 'privacyLevel', 'publishDate')
+    fields = ('author', 'content', 'privacyLevel', 'publishDate')
 
 # Register your models here.
 admin.site.register(Post, PostAdmin)

--- a/social/social/views.py
+++ b/social/social/views.py
@@ -38,7 +38,7 @@ def register(request):
         newUser = User.objects.get(email=userEmail)
 
         # Create and save the Author model
-        author = Author(user=newUser)
+        author = Author(id=newUser)
         author.save()
     except:
         return HttpResponse(sys.exc_info[0]) #TODO: Will need to change this to a nicer UI later


### PR DESCRIPTION
id field should not be declared in admin.py. Also, non-auto primary key fields need to be named id for them to work with Django admin, not sure if there's a way around this.